### PR TITLE
Add Queue drain -- Timeoutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ TODO: Delete this and the text above, and describe your gem
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'sidekiq-web-custom'
+gem 'sidekiq-web_custom'
 ```
 
 And then execute:
@@ -18,7 +18,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install sidekiq-web-custom
+    $ gem install sidekiq-web_custom
 
 ## Usage
 

--- a/lib/sidekiq/views/actions/drain_queue.erb
+++ b/lib/sidekiq/views/actions/drain_queue.erb
@@ -1,4 +1,42 @@
-<form action="<%=root_path %>queues/<%= CGI.escape(queue.name) %>" method="post" style="display: inline">
+<% id = "sidekiq_web_custom_drain_#{queue.name}" %>
+<% text = "#{id}_text" %>
+
+<form onclick="<%= id %>()" action="<%=root_path %>queues/drain/<%= CGI.escape(queue.name) %>" method="post" style="display: inline">
   <%= csrf_tag %>
-  <input class="btn btn-warn btn-xs" type="submit" name="drain" value='Drain Queue' />
+  <input class="btn btn-warn btn-xs" type="submit" name="drain_queue" value="Drain <%= Sidekiq::WebCustom.config.drain_rate %>" />
 </form>
+
+<div id="<%= id %>" style='display: none'>
+  <div id="<%= text %>">Draining queue. Please wait...</div>
+</div>
+
+<script type="text/javascript">
+  function <%= id %>() {
+    document.getElementById("<%= id %>").style.display = "block";
+  }
+</script>
+
+<style>
+#<%= id %> {
+  position: fixed;
+  display: none;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0,0,0,0.8);
+  z-index: 2;
+}
+
+#<%= text %>{
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  font-size: 50px;
+  color: white;
+  transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+}
+</style>

--- a/lib/sidekiq/web_custom.rb
+++ b/lib/sidekiq/web_custom.rb
@@ -1,23 +1,31 @@
 # frozen_string_literal: true
-require 'byebug'
+
 require_relative 'web_custom/version'
 
 # require sidekiq/web first to ensure web_Action will prepend correctly
 require 'sidekiq/web'
+require 'sidekiq/web_custom/configuration'
 require 'sidekiq/web_custom/web_action'
 require 'sidekiq/web_custom/queue'
+require 'sidekiq/web_custom/web_app'
 
 module Sidekiq
   module WebCustom
     class Error < StandardError; end
+    class ArgumentError < Error; end
+    class FileNotFound < Error; end
+    class StopExecution < Error; end
+    class ExecutionTimeExceeded < Error; end
 
-    def self.available_actions_mapping
+    BREAK_BIT = '__sidekiq-web_custom-berakbit__'
+
+    def self.default_available_actions_mapping
       @available_actions_mapping ||= Dir["#{actions_root}/*.erb"].map do |erb_path|
         [File.basename(erb_path).split('.')[0].to_sym, erb_path]
       end.to_h
     end
 
-    def self.local_erb_mapping
+    def self.default_local_erb_mapping
       @local_erb_mapping ||=  Dir["#{local_erbs_root}/*.erb"].map do |erb_path|
         [File.basename(erb_path).split('.')[0].to_sym, erb_path]
       end.to_h
@@ -35,9 +43,38 @@ module Sidekiq
       @root_path ||= File.dirname(__FILE__)
     end
 
-    ::Sidekiq::WebAction.prepend WebAction
-    ::Sidekiq::Queue.prepend Queue
+    def self.config
+      @config ||= Configuration.new.tap do |t|
+        t.merge(base: :actions, params: default_available_actions_mapping)
+        t.merge(base: :local_erbs, params: default_local_erb_mapping)
+      end
+    end
+
+    def self.configure
+      yield config if block_given?
+
+      config.validate!
+      __inject_dependencies
+    end
+
+    def self.available_actions_mapping
+      config.actions
+    end
+
+
+    def self.local_erb_mapping
+      config.local_erbs
+    end
+
+    private
+
+    def self.__inject_dependencies
+      return if @__already_called
+
+      @__already_called = true
+      ::Sidekiq::WebAction.prepend WebAction
+      ::Sidekiq::Queue.prepend Queue
+      ::Sidekiq::Web.register WebApp
+    end
   end
 end
-# Sidekiq::WebCustom.local_erb_mapping
-# byebug

--- a/lib/sidekiq/web_custom/configuration.rb
+++ b/lib/sidekiq/web_custom/configuration.rb
@@ -1,0 +1,81 @@
+require 'byebug'
+
+module Sidekiq
+  module WebCustom
+    class Configuration
+
+      ALLOWED_BASED = [:actions, :local_erbs]
+      INTEGERS = [:drain_rate, :max_execution_time, :warn_execution_time]
+
+      DEFAULT_DRAIN_RATE = 10
+      DEFAULT_EXEC_TIME = 6
+      DEFAULT_WARN_TIME = 5
+      attr_reader *ALLOWED_BASED
+
+      attr_accessor *INTEGERS
+
+      def initialize
+        ALLOWED_BASED.each do |var|
+          instance_variable_set(:"@#{var}", {})
+        end
+
+        @drain_rate = DEFAULT_DRAIN_RATE
+        @max_execution_time = DEFAULT_EXEC_TIME
+        @warn_execution_time = DEFAULT_WARN_TIME
+      end
+
+      def actions
+        @actions
+      end
+
+      def local_erbs
+        @local_erbs
+      end
+
+      INTEGERS.each do |int|
+        define_singleton_method("#{int}=") do |val|
+          raise Sidekiq::WebCustom::ArgumentError, "Expected #{int} to be an integer" unless val.is_a?(Integer)
+
+          super(val)
+        end
+      end
+
+      def drain_rate=(int)
+
+
+        super(int)
+      end
+
+      def merge(base:, params:)
+        raise Sidekiq::WebCustom::ArgumentError, "Unexpected base: #{base}" unless ALLOWED_BASED.include?(base)
+        raise Sidekiq::WebCustom::ArgumentError, "Expected object for #{base} to be a Hash" unless params.is_a?(Hash)
+
+        value = instance_variable_get(:"@#{base}")
+        instance_variable_set(:"@#{base}", value.merge(params))
+      end
+
+      def validate!
+        ALLOWED_BASED.each do |key|
+          value = instance_variable_get(:"@#{key}")
+          _validate!(value, key)
+        end
+
+        return true if @warn_execution_time <= @max_execution_time
+
+        raise Sidekiq::WebCustom::ArgumentError, "Expected warn_execution_time to be less than max_execution_time"
+      end
+
+      private
+
+      def _validate!(params, key)
+        params.each do |k, file|
+          next if File.exist?(file)
+
+          raise Sidekiq::WebCustom::FileNotFound,
+            "#{key}.merge passed #{k}: #{file}.\n" \
+            "The absolute file path does not exist."
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/web_custom/processor.rb
+++ b/lib/sidekiq/web_custom/processor.rb
@@ -3,39 +3,43 @@ require 'sidekiq/processor'
 module Sidekiq
   module WebCustom
     class Processor < ::Sidekiq::Processor
+
       def self.execute(max:, queue:, options: Sidekiq.options)
-        options[:queues] = [queue.name]
-        options[:fetch] = BasicFetch.new(options)
-        processor = new(manager: nil, options: options, queue: queue)
-        processor.execute(max: max)
+        options_temp = options.clone
+        options_temp[:queues] = [queue.name]
+        klass = options_temp[:fetch]&.class || BasicFetch
+        options_temp[:fetch] = klass.new(options_temp)
+        processor = new(manager: nil, options: options_temp, queue: queue)
+        processor.__execute(max: max)
       end
 
       def initialize(manager:, options:, queue:)
         @__queue = queue
+        @__basic_fetch = options[:fetch].class == BasicFetch
 
         super(manager, options)
       end
 
-      def execute_job(job:)
-
-      end
-
-      def execute(max:)
+      def __execute(max:)
         count = 0
         max.times do
           break if @__queue.size <= 0
+          if Thread.current[Sidekiq::WebCustom::BREAK_BIT]
+            Sidekiq.logger.warn { "Yikes -- Break bit has been set. Attempting to return in time. Completed #{count} of attempted #{max}" }
+            break
+          end
           count += 1
-          Sidekiq.logger.info { "Manually processing next item in queue:[#{@__queue}]" }
+          Sidekiq.logger.info { "Manually processing next item in queue:[#{@__queue.name}]" }
           process_one
         end
         count
       rescue Exception => ex
-        if @job
-          Sidekiq.logger.fatal "Processor Execution interupted. Lost Job #{@job}"
+        if @job && @__basic_fetch
+          Sidekiq.logger.fatal "Processor Execution interrupted. Lost Job #{@job.job}"
         end
+        raise ex
       end
     end
   end
 end
 
-# Sidekiq::WebCustom::Processor

--- a/lib/sidekiq/web_custom/timeout.rb
+++ b/lib/sidekiq/web_custom/timeout.rb
@@ -1,0 +1,58 @@
+module Sidekiq
+  module WebCustom
+    module Timeout
+      module_function
+      DEFAULT_EXCEPTION = Sidekiq::WebCustom::ExecutionTimeExceeded
+      PROC = Proc.new do |warn_sec, timeout_sec, proc, exception, message, debug, &block|
+        puts "at: PROC; begining" if debug
+
+        sec_to_raise = timeout_sec - warn_sec
+        begin
+          from = debug ? "from #{caller_locations(1, 1)[0]}" : nil
+          x = Thread.current
+          # do everything in a new thread
+          y = Thread.start {
+            puts "at: PROC; second thread; starting" if debug
+            Thread.current.name = from
+            # block for warning in new thread
+            begin
+              puts "at: PROC; second thread; trying to warn" if debug
+              sleep warn_sec
+            rescue => e
+              x.raise e
+            else
+              # yield back during warning time so downstream can do some prep work
+              proc.call(x, warn_sec)
+            end
+
+            # block additional seconds to raise for
+            begin
+              puts "at: PROC; second thread; trying to raise" if debug
+              sleep sec_to_raise
+            rescue => e
+              x.raise e
+            else
+              x.raise exception, message
+            end
+          }
+          puts "at: PROC; second thread; fully spooled" if debug
+          # after thread starts, yield back to calle function with max timout
+          block.call(timeout_sec)
+        ensure
+          if y
+            y.kill
+            y.join
+          end
+        end
+      end
+
+      def timeout(warn:, timeout:, proc: ->(_, _) {}, exception: DEFAULT_EXCEPTION, message: nil, debug: false, &block)
+        raise Sidekiq::WebCustom::ArgumentError, 'Block not given' unless block_given?
+
+        puts "at: timeout; valid bock given" if debug
+        message ||= "Execution exceeded #{timeout} seconds." if debug
+        PROC.call(warn, timeout, proc, exception, message, debug, &block)
+      end
+    end
+  end
+end

--- a/lib/sidekiq/web_custom/web_app.rb
+++ b/lib/sidekiq/web_custom/web_app.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'sidekiq/web_custom/timeout'
+
+module Sidekiq
+  module WebCustom
+    class WebApp
+      def self.registered(app)
+        app.post '/queues/drain/:name' do
+          timeout_params = {
+            warn: Sidekiq::WebCustom.config.warn_execution_time,
+            timeout: Sidekiq::WebCustom.config.max_execution_time,
+            proc: ->(thread, seconds) { thread[Sidekiq::WebCustom::BREAK_BIT] = 1; puts "set bit #{thread[Sidekiq::WebCustom::BREAK_BIT]}" }
+          }
+          Thread.current[Sidekiq::WebCustom::BREAK_BIT] = nil
+          Sidekiq::WebCustom::Timeout.timeout(timeout_params) do
+            Sidekiq::Queue.new(params[:name]).drain(max: Sidekiq::WebCustom.config.drain_rate)
+          end
+          redirect_with_query("#{root_path}queues")
+        rescue Sidekiq::WebCustom::ExecutionTimeExceeded => e
+          redirect_with_query("#{root_path}queues")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Queue Drain
- Based on configuration, you can decided to drain X number of items at a time. Note that this is a blocking action. 

# Thread warnings and timeout
- Configure max amount of time for a webaction to take -- After X number of seconds the thread stops. This is potentially disastrous as the action is violent and immediate
- Because it is so violent, introduction of a warning -- After warning occurs, the thread will no longer accept new work and attempts to return in time
- This will likely be pulled out into its own Gem and more heavily utilize the timoutable gem