### PR TITLE
Sidekiq 7 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,4 +199,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.3.20
+   2.4.18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-web_custom (0.5.0)
+    sidekiq-web_custom (0.6.0)
       sidekiq (~> 7)
       timeoutable (>= 1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    sidekiq-web_custom (0.4.1)
-      sidekiq (~> 6.5)
+    sidekiq-web_custom (0.5.0)
+      sidekiq (~> 7)
       timeoutable (>= 1.0)
 
 GEM
@@ -76,7 +76,7 @@ GEM
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
-    connection_pool (2.2.5)
+    connection_pool (2.4.1)
     crass (1.0.6)
     diff-lcs (1.5.0)
     digest (3.1.0)
@@ -116,7 +116,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     racc (1.6.0)
-    rack (2.2.4)
+    rack (2.2.8)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.3.1)
@@ -146,7 +146,8 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
-    redis (4.7.1)
+    redis-client (0.15.0)
+      connection_pool
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -162,10 +163,11 @@ GEM
     rspec-support (3.11.0)
     rspec_junit_formatter (0.5.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    sidekiq (6.5.4)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      redis (>= 4.5.0)
+    sidekiq (7.1.2)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.14.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/lib/sidekiq/web_custom/version.rb
+++ b/lib/sidekiq/web_custom/version.rb
@@ -3,7 +3,7 @@
 module Sidekiq
   module WebCustom
     MAJOR = 0  # With backwards incompatability. Requires annoucment and update documentation
-    MINOR = 5  # With feature launch. Documentation of upgrade is useful via a changelog
+    MINOR = 6  # With feature launch. Documentation of upgrade is useful via a changelog
     PATCH = 0  # With minor upgrades or patcing a small bug. No changelog necessary
     VERSION = [MAJOR,MINOR,PATCH].join('.')
 

--- a/sidekiq-web_custom.gemspec
+++ b/sidekiq-web_custom.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'sidekiq', '~> 6.5'
+  spec.add_dependency 'sidekiq', '~> 7'
   spec.add_dependency 'timeoutable', '>= 1.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ if ENV['CI'] =='true'
 end
 
 require "sidekiq/web_custom"
+require "pry"
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
# Problem
Previous versions did not allow an upgrade to Sidekiq v7. This meant that the underlying redis client could not get upgraded either

# Solution

Change some of the internal API structure to allow for the new Capsule structure of SK7

# How to upgrade:
N/a


---

# Note:
Under normal circumstances, this would be a Major version bump since some of the internal public facing API's have changed. However, since this is `1.x >`, a major version bump is not required
